### PR TITLE
Make react-select compatible with react 16

### DIFF
--- a/lib/Async.js
+++ b/lib/Async.js
@@ -8,6 +8,16 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+var _reactDom = require('react-dom');
+
 var _Select = require('./Select');
 
 var _Select2 = _interopRequireDefault(_Select);
@@ -49,23 +59,23 @@ function thenPromise(promise, callback) {
 	});
 }
 
-var stringOrNode = _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.string, _react2['default'].PropTypes.node]);
+var stringOrNode = _propTypes2['default'].oneOfType([_propTypes2['default'].string, _propTypes2['default'].node]);
 
-var Async = _react2['default'].createClass({
+var Async = _createReactClass2['default']({
 	displayName: 'Async',
 
 	propTypes: {
-		cache: _react2['default'].PropTypes.any, // object to use to cache results, can be null to disable cache
-		ignoreAccents: _react2['default'].PropTypes.bool, // whether to strip diacritics when filtering (shared with Select)
-		ignoreCase: _react2['default'].PropTypes.bool, // whether to perform case-insensitive filtering (shared with Select)
-		isLoading: _react2['default'].PropTypes.bool, // overrides the isLoading state when set to true
-		loadOptions: _react2['default'].PropTypes.func.isRequired, // function to call to load options asynchronously
-		loadingPlaceholder: _react2['default'].PropTypes.string, // replaces the placeholder while options are loading
-		minimumInput: _react2['default'].PropTypes.number, // the minimum number of characters that trigger loadOptions
-		noResultsText: _react2['default'].PropTypes.string, // placeholder displayed when there are no matching search results (shared with Select)
+		cache: _propTypes2['default'].any, // object to use to cache results, can be null to disable cache
+		ignoreAccents: _propTypes2['default'].bool, // whether to strip diacritics when filtering (shared with Select)
+		ignoreCase: _propTypes2['default'].bool, // whether to perform case-insensitive filtering (shared with Select)
+		isLoading: _propTypes2['default'].bool, // overrides the isLoading state when set to true
+		loadOptions: _propTypes2['default'].func.isRequired, // function to call to load options asynchronously
+		loadingPlaceholder: _propTypes2['default'].string, // replaces the placeholder while options are loading
+		minimumInput: _propTypes2['default'].number, // the minimum number of characters that trigger loadOptions
+		noResultsText: _propTypes2['default'].string, // placeholder displayed when there are no matching search results (shared with Select)
 		placeholder: stringOrNode, // field placeholder, displayed when there's no value (shared with Select)
-		searchPromptText: _react2['default'].PropTypes.string, // label to prompt for search input
-		searchingText: _react2['default'].PropTypes.string },
+		searchPromptText: _propTypes2['default'].string, // label to prompt for search input
+		searchingText: _propTypes2['default'].string },
 	// message to display while options are loading
 	getDefaultProps: function getDefaultProps() {
 		return {
@@ -90,6 +100,7 @@ var Async = _react2['default'].createClass({
 	},
 	componentDidMount: function componentDidMount() {
 		this.loadOptions('');
+    this.mounted = true;
 	},
 	componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
 		if (nextProps.cache !== this.props.cache) {
@@ -114,7 +125,7 @@ var Async = _react2['default'].createClass({
 		var _requestId = this._currentRequestId = requestId++;
 		return function (err, data) {
 			if (err) throw err;
-			if (!_this.isMounted()) return;
+			if (!_this.mounted) return;
 			updateCache(_this.state.cache, input, data);
 			if (_requestId !== _this._currentRequestId) return;
 			_this.setState({

--- a/lib/Option.js
+++ b/lib/Option.js
@@ -6,23 +6,33 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+var _reactDom = require('react-dom');
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var Option = _react2['default'].createClass({
+var Option = _createReactClass2['default']({
 	displayName: 'Option',
 
 	propTypes: {
-		children: _react2['default'].PropTypes.node,
-		className: _react2['default'].PropTypes.string, // className (based on mouse position)
-		isDisabled: _react2['default'].PropTypes.bool, // the option is disabled
-		isFocused: _react2['default'].PropTypes.bool, // the option is focused
-		isSelected: _react2['default'].PropTypes.bool, // the option is selected
-		onFocus: _react2['default'].PropTypes.func, // method to handle mouseEnter on option element
-		onSelect: _react2['default'].PropTypes.func, // method to handle click on option element
-		onUnfocus: _react2['default'].PropTypes.func, // method to handle mouseLeave on option element
-		option: _react2['default'].PropTypes.object.isRequired },
+		children: _propTypes2['default'].node,
+		className: _propTypes2['default'].string, // className (based on mouse position)
+		isDisabled: _propTypes2['default'].bool, // the option is disabled
+		isFocused: _propTypes2['default'].bool, // the option is focused
+		isSelected: _propTypes2['default'].bool, // the option is selected
+		onFocus: _propTypes2['default'].func, // method to handle mouseEnter on option element
+		onSelect: _propTypes2['default'].func, // method to handle click on option element
+		onUnfocus: _propTypes2['default'].func, // method to handle mouseLeave on option element
+		option: _propTypes2['default'].object.isRequired },
 	// object that is base for that option
 	blockEvent: function blockEvent(event) {
 		event.preventDefault();

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -12,6 +12,14 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
@@ -48,65 +56,65 @@ function stringifyValue(value) {
 	}
 }
 
-var stringOrNode = _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.string, _react2['default'].PropTypes.node]);
+var stringOrNode = _propTypes2['default'].oneOfType([_propTypes2['default'].string, _propTypes2['default'].node]);
 
-var Select = _react2['default'].createClass({
+var Select = _createReactClass2['default']({
 
 	displayName: 'Select',
 
 	propTypes: {
-		addLabelText: _react2['default'].PropTypes.string, // placeholder displayed when you want to add a label on a multi-value input
-		allowCreate: _react2['default'].PropTypes.bool, // whether to allow creation of new entries
-		autoBlur: _react2['default'].PropTypes.bool,
-		autofocus: _react2['default'].PropTypes.bool, // autofocus the component on mount
-		backspaceRemoves: _react2['default'].PropTypes.bool, // whether backspace removes an item if there is no text input
-		className: _react2['default'].PropTypes.string, // className for the outer element
+		addLabelText: _propTypes2['default'].string, // placeholder displayed when you want to add a label on a multi-value input
+		allowCreate: _propTypes2['default'].bool, // whether to allow creation of new entries
+		autoBlur: _propTypes2['default'].bool,
+		autofocus: _propTypes2['default'].bool, // autofocus the component on mount
+		backspaceRemoves: _propTypes2['default'].bool, // whether backspace removes an item if there is no text input
+		className: _propTypes2['default'].string, // className for the outer element
 		clearAllText: stringOrNode, // title for the "clear" control when multi: true
 		clearValueText: stringOrNode, // title for the "clear" control
-		clearable: _react2['default'].PropTypes.bool, // should it be possible to reset value
-		delimiter: _react2['default'].PropTypes.string, // delimiter to use to join multiple values for the hidden field value
-		disabled: _react2['default'].PropTypes.bool, // whether the Select is disabled or not
-		escapeClearsValue: _react2['default'].PropTypes.bool, // whether escape clears the value when the menu is closed
-		filterOption: _react2['default'].PropTypes.func, // method to filter a single option (option, filterString)
-		filterOptions: _react2['default'].PropTypes.any, // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
-		ignoreAccents: _react2['default'].PropTypes.bool, // whether to strip diacritics when filtering
-		ignoreCase: _react2['default'].PropTypes.bool, // whether to perform case-insensitive filtering
-		inputProps: _react2['default'].PropTypes.object, // custom attributes for the Input
-		isLoading: _react2['default'].PropTypes.bool, // whether the Select is loading externally or not (such as options being loaded)
-		labelKey: _react2['default'].PropTypes.string, // path of the label value in option objects
-		matchPos: _react2['default'].PropTypes.string, // (any|start) match the start or entire string when filtering
-		matchProp: _react2['default'].PropTypes.string, // (any|label|value) which option property to filter on
-		menuBuffer: _react2['default'].PropTypes.number, // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
-		menuContainerStyle: _react2['default'].PropTypes.object, // optional style to apply to the menu container
-		menuStyle: _react2['default'].PropTypes.object, // optional style to apply to the menu
-		multi: _react2['default'].PropTypes.bool, // multi-value input
-		name: _react2['default'].PropTypes.string, // generates a hidden <input /> tag with this field name for html forms
-		newOptionCreator: _react2['default'].PropTypes.func, // factory to create new options when allowCreate set
+		clearable: _propTypes2['default'].bool, // should it be possible to reset value
+		delimiter: _propTypes2['default'].string, // delimiter to use to join multiple values for the hidden field value
+		disabled: _propTypes2['default'].bool, // whether the Select is disabled or not
+		escapeClearsValue: _propTypes2['default'].bool, // whether escape clears the value when the menu is closed
+		filterOption: _propTypes2['default'].func, // method to filter a single option (option, filterString)
+		filterOptions: _propTypes2['default'].any, // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
+		ignoreAccents: _propTypes2['default'].bool, // whether to strip diacritics when filtering
+		ignoreCase: _propTypes2['default'].bool, // whether to perform case-insensitive filtering
+		inputProps: _propTypes2['default'].object, // custom attributes for the Input
+		isLoading: _propTypes2['default'].bool, // whether the Select is loading externally or not (such as options being loaded)
+		labelKey: _propTypes2['default'].string, // path of the label value in option objects
+		matchPos: _propTypes2['default'].string, // (any|start) match the start or entire string when filtering
+		matchProp: _propTypes2['default'].string, // (any|label|value) which option property to filter on
+		menuBuffer: _propTypes2['default'].number, // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
+		menuContainerStyle: _propTypes2['default'].object, // optional style to apply to the menu container
+		menuStyle: _propTypes2['default'].object, // optional style to apply to the menu
+		multi: _propTypes2['default'].bool, // multi-value input
+		name: _propTypes2['default'].string, // generates a hidden <input /> tag with this field name for html forms
+		newOptionCreator: _propTypes2['default'].func, // factory to create new options when allowCreate set
 		noResultsText: stringOrNode, // placeholder displayed when there are no matching search results
-		onBlur: _react2['default'].PropTypes.func, // onBlur handler: function (event) {}
-		onBlurResetsInput: _react2['default'].PropTypes.bool, // whether input is cleared on blur
-		onChange: _react2['default'].PropTypes.func, // onChange handler: function (newValue) {}
-		onClose: _react2['default'].PropTypes.func, // fires when the menu is closed
-		onFocus: _react2['default'].PropTypes.func, // onFocus handler: function (event) {}
-		onInputChange: _react2['default'].PropTypes.func, // onInputChange handler: function (inputValue) {}
-		onMenuScrollToBottom: _react2['default'].PropTypes.func, // fires when the menu is scrolled to the bottom; can be used to paginate options
-		onOpen: _react2['default'].PropTypes.func, // fires when the menu is opened
-		onValueClick: _react2['default'].PropTypes.func, // onClick handler for value labels: function (value, event) {}
-		optionComponent: _react2['default'].PropTypes.func, // option component to render in dropdown
-		optionRenderer: _react2['default'].PropTypes.func, // optionRenderer: function (option) {}
-		options: _react2['default'].PropTypes.array, // array of options
+		onBlur: _propTypes2['default'].func, // onBlur handler: function (event) {}
+		onBlurResetsInput: _propTypes2['default'].bool, // whether input is cleared on blur
+		onChange: _propTypes2['default'].func, // onChange handler: function (newValue) {}
+		onClose: _propTypes2['default'].func, // fires when the menu is closed
+		onFocus: _propTypes2['default'].func, // onFocus handler: function (event) {}
+		onInputChange: _propTypes2['default'].func, // onInputChange handler: function (inputValue) {}
+		onMenuScrollToBottom: _propTypes2['default'].func, // fires when the menu is scrolled to the bottom; can be used to paginate options
+		onOpen: _propTypes2['default'].func, // fires when the menu is opened
+		onValueClick: _propTypes2['default'].func, // onClick handler for value labels: function (value, event) {}
+		optionComponent: _propTypes2['default'].func, // option component to render in dropdown
+		optionRenderer: _propTypes2['default'].func, // optionRenderer: function (option) {}
+		options: _propTypes2['default'].array, // array of options
 		placeholder: stringOrNode, // field placeholder, displayed when there's no value
-		required: _react2['default'].PropTypes.bool, // applies HTML5 required attribute when needed
-		scrollMenuIntoView: _react2['default'].PropTypes.bool, // boolean to enable the viewport to shift so that the full menu fully visible when engaged
-		searchable: _react2['default'].PropTypes.bool, // whether to enable searching feature or not
-		simpleValue: _react2['default'].PropTypes.bool, // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
-		style: _react2['default'].PropTypes.object, // optional style to apply to the control
-		tabIndex: _react2['default'].PropTypes.string, // optional tab index of the control
-		value: _react2['default'].PropTypes.any, // initial field value
-		valueComponent: _react2['default'].PropTypes.func, // value component to render
-		valueKey: _react2['default'].PropTypes.string, // path of the label value in option objects
-		valueRenderer: _react2['default'].PropTypes.func, // valueRenderer: function (option) {}
-		wrapperStyle: _react2['default'].PropTypes.object },
+		required: _propTypes2['default'].bool, // applies HTML5 required attribute when needed
+		scrollMenuIntoView: _propTypes2['default'].bool, // boolean to enable the viewport to shift so that the full menu fully visible when engaged
+		searchable: _propTypes2['default'].bool, // whether to enable searching feature or not
+		simpleValue: _propTypes2['default'].bool, // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
+		style: _propTypes2['default'].object, // optional style to apply to the control
+		tabIndex: _propTypes2['default'].string, // optional tab index of the control
+		value: _propTypes2['default'].any, // initial field value
+		valueComponent: _propTypes2['default'].func, // value component to render
+		valueKey: _propTypes2['default'].string, // path of the label value in option objects
+		valueRenderer: _propTypes2['default'].func, // valueRenderer: function (option) {}
+		wrapperStyle: _propTypes2['default'].object },
 
 	// optional style to apply to the component wrapper
 	statics: { Async: _Async2['default'] },

--- a/lib/Value.js
+++ b/lib/Value.js
@@ -6,20 +6,30 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+var _reactDom = require('react-dom');
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var Value = _react2['default'].createClass({
+var Value = _createReactClass2['default']({
 
 	displayName: 'Value',
 
 	propTypes: {
-		children: _react2['default'].PropTypes.node,
-		disabled: _react2['default'].PropTypes.bool, // disabled prop passed to ReactSelect
-		onClick: _react2['default'].PropTypes.func, // method to handle click on value label
-		onRemove: _react2['default'].PropTypes.func, // method to handle removal of the value
-		value: _react2['default'].PropTypes.object.isRequired },
+		children: _propTypes2['default'].node,
+		disabled: _propTypes2['default'].bool, // disabled prop passed to ReactSelect
+		onClick: _propTypes2['default'].func, // method to handle click on value label
+		onRemove: _propTypes2['default'].func, // method to handle removal of the value
+		value: _propTypes2['default'].object.isRequired },
 
 	// the option object for this value
 	handleMouseDown: function handleMouseDown(event) {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "babel-eslint": "^4.1.3",
     "chai": "^3.4.1",
     "coveralls": "^2.11.6",
+    "create-react-class": "^15.6.3",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.15.0",
     "gulp": "^3.9.0",
     "istanbul": "^0.4.2",
     "jsdom": "^7.2.2",
     "mocha": "^2.3.4",
+    "prop-types": "^15.6.1",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-component-gulp-tasks": "^0.7.7",
@@ -37,8 +39,8 @@
     "unexpected-sinon": "^9.0.4"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^0.14.0 || ^16.0",
+    "react-dom": "^0.14.0 || ^16.0"
   },
   "browserify-shim": {
     "classnames": "global:classNames",


### PR DESCRIPTION
Basically just adds the `create-react-class` and `prop-types` patches.